### PR TITLE
feat: add async support, per-task timeout enforcement, and structured logging

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,10 +26,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install build
-          pip install -r requirements.txt
-
-      - name: Install testing dependencies
-        run: pip install -r dev-requirements.txt
+          pip install .
+          pip install .[test]
 
       - name: Run tests with pytest
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.1.0] - 2025-07-14
+
+### Added
+- **Async support**: Introduced `@timeit_async` for timing `async def` functions.
+- **Per-task timeout enforcement** via `enforce_timeout=True` for both sync and async.
+- **Support for static, class, and instance methods**, with multiprocessing compatibility.
+- **Graceful timeout with `asyncio.shield()`** for non-enforced async timeouts.
+- **Detailed logging** output using `tabulate`, replacing all `print()` usage.
+- Pytest-based test suite for all sync/async variants, timeout handling, and method types.
+
+### Changed
+- `@timeit` is now **deprecated** and issues a `DeprecationWarning`. It automatically redirects to the correct decorator based on function type.
+- Logging configuration is initialized only if no handlers are configured (`logging.basicConfig(...)`).
+- Multiprocessing mode now explicitly rejects `enforce_timeout=True` with a `ValueError`.
+
+### Tests
+- Added over 40 Pytest tests covering:
+  - Async/sync behavior
+  - Timeout enforcement and fallback
+  - CPU-bound, I/O-bound, and error cases
+  - Generator functions
+  - Class, static, and instance method support
+
+### Internal
+- Refactored into separate modules:
+  - `timeit_sync.py`
+  - `timeit_async.py`
+  - `timeit.py` (deprecated redirector)
+- Modular structure ready for packaging and long-term maintenance.
+
+---
+
+## [2.0.8] - 2025-06-25
+
+Initial public release.

--- a/README.md
+++ b/README.md
@@ -10,27 +10,59 @@
 [![GitHub Issues](https://img.shields.io/github/issues/jubnl/timeit_decorator)](https://github.com/jubnl/timeit_decorator/issues)
 ![GitHub Repo stars](https://img.shields.io/github/stars/jubnl/timeit_decorator)
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Features](#features)
+- [Flexible Logging](#flexible-logging)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Basic Usage](#basic-usage)
+  - [Efficient Execution for Single Run/Worker](#efficient-execution-for-single-runworker)
+  - [Using Multiprocessing](#using-multiprocessing)
+  - [Using Threading (Default)](#using-threading-default)
+  - [Detailed Output Option](#detailed-output-option)
+  - [Timeout Handling](#timeout-handling)
+  - [Async Support](#async-support)
+- [Limitations](#limitations)
+  - [Incompatibility with Static Methods and Multiprocessing](#incompatibility-with-static-methods-and-multiprocessing)
+- [Requirements](#requirements)
+- [Contributing](#contributing)
+- [License](#license)
+- [Changelog](#changelog)
+
 
 ## Overview
 
-`timeit_decorator` is a Python package providing a versatile decorator for timing the execution of functions. It
-supports executing functions multiple times, in parallel, and can use either threading or multiprocessing depending on
-the nature of the task.
+`timeit_decorator` is a flexible Python library for benchmarking function execution. It supports repeated runs, parallel
+execution with threads or processes, detailed timing statistics, and native support for both sync and async functions.
 
-## Efficient Execution for Single Run/Worker
+## Features
 
-The decorator is optimized for scenarios where both runs and workers are set to 1. In such cases, it bypasses the
-overhead of setting up a pool and directly executes the function, which is more efficient for single-run executions.
+- **Multiple Runs and Workers**: Run functions multiple times with configurable concurrency.
+- **Sync and Async Support**: Use @timeit_sync or @timeit_async for full feature parity across sync and async code.
+- **Per-Task Timeout Handling**: Enforce or log timeouts individually for each execution.
+- **Multiprocessing and Threading**: Choose concurrency model for CPU- or I/O-bound workloads.
+- **Detailed Statistics**: Enable detailed=True to log timing metrics like average, median, min/max, stddev.
+- **Instance, Class, and Static Method Support**: Fully supports method decorators (with limitations for
+  multiprocessing).
+- **Structured Logging Only**: All output is logged using Python’s logging module.
+
+##### Use Cases
+
+- **Performance Analysis**: Use the `detailed` parameter to get a comprehensive overview of the function's performance
+  across multiple runs.
+- **Debugging**: The detailed statistics can help identify inconsistencies or anomalies in function execution, aiding in
+  debugging efforts.
+
+Remember that enabling detailed output can increase the verbosity of the output, especially for functions executed
+multiple times. It is recommended to use this feature judiciously based on the specific needs of performance analysis or
+debugging.
 
 ## Flexible Logging
 
-The `timeit_decorator` can either log timing information using Python's logging framework or print it directly to the
-console. This behavior is controlled by the `log_level` parameter:
-
-- If a log level is specified (e.g., `logging.INFO`), the timing information will be logged at that level.
-- If `log_level` is set to `None`, the timing information will be printed directly to the console.
-
-By default, the `log_level` parameter is set to `logging.INFO`.
+All output is handled exclusively through Python’s `logging` module. The `timeit_decorator` automatically configures a
+default logger if none exists. You can customize verbosity using the `log_level` parameter (default: `logging.INFO`).
 
 ## Installation
 
@@ -53,7 +85,7 @@ Here's how to use the timeit decorator:
 
 ```py
 import logging
-from timeit_decorator import timeit
+from timeit_decorator import timeit_sync
 
 # Configure logging
 logging.basicConfig(
@@ -63,7 +95,7 @@ logging.basicConfig(
 )
 
 
-@timeit(runs=5, workers=2, log_level=logging.INFO)
+@timeit_sync(runs=5, workers=2, log_level=logging.INFO)
 def sample_function():
     # Function implementation
     pass
@@ -79,15 +111,23 @@ For single executions, the decorator directly runs the function:
 
 ```py
 import logging
-from timeit_decorator import timeit
+from timeit_decorator import timeit_sync
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 
 
 # Default parameters
-# @timeit(runs=1, workers=1, log_level=logging.INFO, use_multiprocessing=False)
-@timeit()
+# @timeit_sync(
+#       runs=1,
+#       workers=1,
+#       log_level=logging.INFO,
+#       use_multiprocessing=False,
+#       detailed=False,
+#       timeout=None,
+#       enforce_timeout=False
+# )
+@timeit_sync()
 def quick_function():
     # Function implementation for a quick task
     pass
@@ -103,13 +143,13 @@ For CPU-bound tasks, you can enable multiprocessing:
 
 ```py
 import logging
-from timeit_decorator import timeit
+from timeit_decorator import timeit_sync
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-@timeit(runs=10, workers=4, use_multiprocessing=True, log_level=logging.DEBUG)
+@timeit_sync(runs=10, workers=4, use_multiprocessing=True, log_level=logging.DEBUG)
 def cpu_intensive_function():
     # CPU-bound function implementation
     pass
@@ -125,13 +165,13 @@ For I/O-bound tasks, the default threading is more efficient:
 
 ```py
 import logging
-from timeit_decorator import timeit
+from timeit_decorator import timeit_sync
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 
 
-@timeit(runs=5, workers=2)
+@timeit_sync(runs=5, workers=2)
 def io_bound_function():
     # I/O-bound function implementation
     pass
@@ -157,7 +197,7 @@ and maximum execution times, standard deviation, and total execution time for al
 ##### Example
 
 ```py
-@timeit(runs=5, workers=2, detailed=True)
+@timeit_sync(runs=5, workers=2, detailed=True)
 def sample_function(a, b, c="some value"):
     # Function implementation
     pass
@@ -182,63 +222,85 @@ Std Deviation  0.015s
 Total Time     1.0s
 ```
 
-##### Use Cases
-
-- **Performance Analysis**: Use the `detailed` parameter to get a comprehensive overview of the function's performance
-  across multiple runs.
-- **Debugging**: The detailed statistics can help identify inconsistencies or anomalies in function execution, aiding in
-  debugging efforts.
-
-Remember that enabling detailed output can increase the verbosity of the output, especially for functions executed
-multiple times. It is recommended to use this feature judiciously based on the specific needs of performance analysis or
-debugging.
-
 ### Timeout Handling
 
-The timeit decorator includes a timeout mechanism to monitor execution time without stopping the function. If the
-execution time exceeds the specified timeout, the decorator logs a warning but allows the function to complete.
+You can specify a `timeout` (in seconds) to monitor execution duration for each run. The `enforce_timeout` parameter
+controls how timeouts are handled:
 
-#### Usage Example
+- `enforce_timeout=False` (default): Logs a warning if a run exceeds the timeout but allows it to complete.
+- `enforce_timeout=True`: Cancels the execution if the timeout is reached (only supported with threading and async).
+
+#### Example (Non-Enforced Timeout)
 
 ```python
 import logging
-from timeit_decorator import timeit
+from timeit_decorator import timeit_sync
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 
 
-@timeit(timeout=0.1, log_level=logging.WARNING)
+@timeit_sync(timeout=0.1)
 def slow_function():
     import time
-    time.sleep(0.2)  # Simulate a slow function
+    time.sleep(0.2)
 
 
 slow_function()
 ```
 
-#### Behavior
+Example (Enforced Timeout with Cancellation)
 
-- If the function executes within the timeout, it completes normally.
-- If the function exceeds the timeout, a warning is logged:
+```python
+@timeit_sync(timeout=0.1, enforce_timeout=True)
+def fast_abort():
+    import time
+    time.sleep(0.2)
 
-```log
-WARNING: Timeout exceeded (took 0.205s, timeout was 0.1s), but execution continued.
+
+fast_abort()
 ```
 
-The function result is still returned even if the timeout is exceeded.
+#### Behavior Summary
 
-## Features
+- If execution completes before timeout -> normal result
+- If enforce_timeout=False and timeout is exceeded -> logs warning, allows completion
+- If enforce_timeout=True and timeout is exceeded -> run is cancelled and marked as timed out
 
-- **Multiple Runs and Workers**: Execute the function multiple times in parallel for more accurate timing.
-- **Flexible Logging**: Choose between logging framework or direct print to console for output.
-- **Optimized for Single Execution**: Efficient for single run/worker scenarios.
-- **Supports Multiprocessing and Threading**: Suitable for both CPU-bound and I/O-bound tasks.
+> Note: Enforced timeout is not supported with use_multiprocessing=True due to Python’s process model.
+
+### Async Support
+
+`timeit_decorator` fully supports asynchronous functions via the `@timeit_async` decorator.
+
+You can configure it with the same options as the sync version, including:
+
+- `runs`, `workers`
+- `timeout`, `enforce_timeout`
+- `detailed`, `log_level`
+
+Async execution uses an internal `asyncio.Semaphore` to manage concurrency and supports both enforced and non-enforced
+timeouts via `asyncio.wait_for()` and `asyncio.shield()`.
+
+```python
+import asyncio
+from timeit_decorator import timeit_async
+
+
+@timeit_async(runs=3, workers=2, timeout=0.1, enforce_timeout=False)
+async def async_task():
+    await asyncio.sleep(0.2)
+    return "done"
+
+
+asyncio.run(async_task())
+```
+
+> If `enforce_timeout=False`, timeouts are logged but the coroutine is allowed to finish using `asyncio.shield()`.
+> If `enforce_timeout=True`, the task is cancelled if it exceeds the timeout limit.
 
 ## Limitations
 
-While the `timeit` decorator is designed to be versatile and useful in a wide range of scenarios, there are certain
-limitations that users should be aware of:
+While `timeit_decorator` is designed to be highly flexible, a few constraints exist due to Python's concurrency model:
 
 ### Incompatibility with Static Methods and Multiprocessing
 
@@ -270,7 +332,7 @@ Example of exception :
 _pickle.PicklingError: Can't pickle <function ExampleClass.example_static_method at 0x...>: it's not the same object as __main__.ExampleClass.example_static_method
 ```
 
-**Recommended Workaround**:To avoid this issue, consider using instance methods or regular functions, which are not
+**Recommended Workaround**: To avoid this issue, consider using instance methods or regular functions, which are not
 subject to the same serialization constraints as static methods. Alternatively, refrain from using
 `use_multiprocessing=True` with static methods.
 
@@ -291,3 +353,7 @@ details.
 ## License
 
 `timeit_decorator` is released under the [MIT License](./LICENSE).
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md) for a full list of changes, fixes, and new features introduced in each release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ keywords = [
 [project.optional-dependencies]
 test = [
     "pytest",
-    "pytest-cov"
+    "pytest-cov",
+    "pytest-asyncio"
 ]
 
 [project.urls]
@@ -54,3 +55,7 @@ Issues = "https://github.com/jubnl/timeit_decorator/issues"
 
 [project.scripts]
 timeit_decorator = "timeit_decorator.__main__:main"
+
+[pytest]
+markers = "asyncio"
+

--- a/timeit_decorator/__init__.py
+++ b/timeit_decorator/__init__.py
@@ -1,1 +1,3 @@
 from .timeit import timeit
+from .sync_wrapper import timeit_sync
+from .async_wrapper import timeit_async

--- a/timeit_decorator/async_wrapper.py
+++ b/timeit_decorator/async_wrapper.py
@@ -1,0 +1,201 @@
+import asyncio
+import logging
+import multiprocessing
+import threading
+import time
+from functools import wraps
+from statistics import mean, median, stdev
+from typing import Optional, Callable
+
+from tabulate import tabulate
+
+
+def timeit_async(
+        runs: int = 1,
+        workers: int = 1,
+        log_level: Optional[int] = logging.INFO,
+        use_multiprocessing: bool = False,
+        detailed: bool = False,
+        timeout: Optional[float] = None,
+        enforce_timeout: bool = False
+):
+    """
+        Time the execution of a function with options for multiple runs and workers.
+
+        This decorator can use either threading or multiprocessing for executing the
+        function multiple times in parallel, depending on the nature of the task.
+        It measures and logs the execution time, reporting the average and median times.
+
+        :param runs: Number of times to run the function (minimum 1).
+        :type runs: int
+        :param workers: Number of concurrent workers (minimum 1, max equals 'runs').
+        :type workers: int
+        :param log_level: Logging level for timing information (e.g., logging.INFO).
+        :type log_level: Optional[int]
+        :param use_multiprocessing: Use multiprocessing if True, otherwise use threading.
+                                    Suitable for CPU-bound tasks when True.
+        :type use_multiprocessing: bool
+        :param detailed: get a detailed output with different stats about the execution time.
+        :type detailed: bool
+        :param timeout: An optional timeout in seconds for each function execution.
+        :type timeout: Optional[float]
+        :param enforce_timeout: Enforce timeout. False by default. If True and the timeout is reached, it will cancel the
+                                execution. Does not work in single execution in sync mode.
+        :type enforce_timeout: bool
+        :return: The return value of the function from its first execution.
+        :rtype: Any
+        :raises ValueError: If 'runs' or 'workers' are set to less than 1.
+
+        For I/O-bound tasks (like file operations, network calls), threading is generally
+        more efficient due to lower overhead and the GIL's release during I/O operations.
+        For CPU-bound tasks, multiprocessing bypasses the GIL and may provide better performance.
+
+        .. note::
+           Choose the execution mode (threading or multiprocessing) based on the task at hand.
+           Threading is the default mode for its efficiency with I/O-bound tasks.
+
+        **Example**::
+
+            @timeit(runs=10, workers=4, log_level=logging.DEBUG, use_multiprocessing=True)
+            def cpu_intensive_function(n):
+                # Function implementation
+
+            @timeit(runs=5, workers=2)
+            def io_bound_function(n):
+                # Function implementation
+        """
+
+    if runs < 1 or workers < 1:
+        raise ValueError("Both runs and workers must be at least 1")
+
+    # Ensure workers do not exceed number of runs
+    workers = min(workers, runs)
+
+    if log_level is None:
+        log_level = logging.INFO
+
+    def decorator(func: Callable):
+        logger = logging.getLogger("timeit.decorator")
+        logger.setLevel(log_level)
+
+        if not logging.getLogger().hasHandlers():
+            logging.basicConfig(
+                level=log_level,
+                format="%(asctime)s [%(levelname)s] (%(name)s) %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S"
+            )
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            if threading.current_thread() is not threading.main_thread():
+                return await func(*args, **kwargs)
+            if multiprocessing.current_process().name != 'MainProcess':
+                return await func(*args, **kwargs)
+
+            async def run_once():
+                try:
+                    start_time = time.time()
+                    coro = func(*args, **kwargs)
+
+                    if timeout:
+                        task = asyncio.create_task(coro)
+
+                        if not enforce_timeout:
+                            # Wait for the task with timeout, but don’t cancel on timeout
+                            done, pending = await asyncio.wait({task}, timeout=timeout)
+                            if task in done:
+                                result = await task
+                                duration = time.time() - start_time
+                                return duration, result, False
+                            else:
+                                logger.warning(f"{func.__name__} exceeded timeout of {timeout}s but continued running.")
+                                result = await task  # allow it to finish
+                                duration = time.time() - start_time
+                                return duration, result, True
+                        else:
+                            try:
+                                result = await asyncio.wait_for(task, timeout=timeout)
+                                duration = time.time() - start_time
+                                return duration, result, False
+                            except asyncio.TimeoutError:
+                                logger.warning(
+                                    f"{func.__name__} exceeded enforced timeout of {timeout}s and was canceled.")
+                                duration = time.time() - start_time
+                                return duration, None, True
+                    else:
+                        result = await coro
+                        duration = time.time() - start_time
+                        return duration, result, False
+
+                except Exception as e:
+                    logger.error(f"Error during async execution: {e}")
+                    return None, None, False
+
+            if runs == 1 and workers == 1:
+                duration, result, _ = await run_once()
+                if detailed:
+                    output = tabulate([
+                        ["Function", func],
+                        ["Args", args[1:] if args else []],
+                        ["Kwargs", kwargs],
+                        ["Duration", f"{duration}s"]
+                    ], tablefmt="plain")
+                else:
+                    output = f"{func.__name__}: Exec: {duration:.6f}s"
+                logger.log(log_level, output)
+                return result
+
+            sem = asyncio.Semaphore(workers)
+
+            async def limited_run():
+                async with sem:
+                    return await run_once()
+
+            tasks = [limited_run() for _ in range(runs)]
+            results = await asyncio.gather(*tasks)
+
+            times = [r[0] for r in results if r and r[0] is not None]
+            valid_results = [r[1] for r in results if r and r[1] is not None]
+            timed_out = [r[2] for r in results if r and r[2] is not None]
+
+            if not times:
+                logger.error(f"{func.__name__}: All async function executions failed or returned None.")
+                return None if not detailed else []
+
+            avg_time = mean(times)
+            med_time = median(times)
+            min_time = min(times)
+            max_time = max(times)
+            std_dev = stdev(times) if len(times) > 1 else 0
+            total_time = sum(times)
+
+            if detailed:
+                stats_data = [
+                    ["Function", func],
+                    ["Args", args[1:] if args else []],
+                    ["Kwargs", kwargs],
+                    ["Runs", runs],
+                    ["Workers", workers],
+                    ["Average Time", f"{avg_time}s"],
+                    ["Median Time", f"{med_time}s"],
+                    ["Min Time", f"{min_time}s"],
+                    ["Max Time", f"{max_time}s"],
+                    ["Std Deviation", f"{std_dev}s"],
+                    ["Total Time", f"{total_time}s"],
+                    ["Timed Out", any(timed_out)],
+                ]
+                output = tabulate(stats_data, tablefmt="plain")
+            else:
+                output = f"{func}: Avg: {avg_time:.3f}s, Med: {med_time:.3f}s"
+
+            logger.log(log_level, output)
+
+            for result in valid_results:
+                if result is not None:
+                    return result
+
+            return None
+
+        return async_wrapper
+
+    return decorator

--- a/timeit_decorator/sync_wrapper.py
+++ b/timeit_decorator/sync_wrapper.py
@@ -1,0 +1,255 @@
+import logging
+import multiprocessing
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from functools import wraps
+from multiprocessing import Pool
+from statistics import stdev, median, mean
+from typing import Optional, Callable
+
+from tabulate import tabulate
+
+
+def _multiprocessing_instance_method_call(instance, method_name, *args, **kwargs):
+    """Call an instance method by name using reflection (used in multiprocessing)."""
+    method = getattr(instance, method_name)
+    return method(*args, **kwargs)
+
+
+def _timeit_worker(worker_args):
+    """Worker function that executes a function and applies a timeout."""
+    logger = logging.getLogger("timeit.decorator._timeit_worker")
+    try:
+        # Distinguish between instance method and regular function
+        if isinstance(worker_args, tuple) and isinstance(worker_args[1], str):
+            instance, method_name, method_args, method_kwargs, timeout, enforce_timeout = worker_args
+            wrapped_func = lambda: getattr(instance, method_name)(*method_args, **method_kwargs)
+        else:
+            func, func_args, func_kwargs, timeout, enforce_timeout = worker_args
+            wrapped_func = lambda: func(*func_args, **func_kwargs)
+
+        # Enforce timeout using a thread-based executor
+        timed_out = False
+
+        # Time the function execution
+        execution_start = time.time()
+        func_result = wrapped_func()
+        execution_time = time.time() - execution_start
+
+        # Log if execution time exceeded timeout but was not forcibly stopped
+        if timeout is not None and execution_time > timeout and not enforce_timeout:
+            logger.warning(
+                f"Timeout exceeded (took {execution_time}s, timeout was {timeout}s), but execution continued.")
+            timed_out = True
+
+        return execution_time, func_result, timed_out
+
+    except Exception as e:
+        logging.error(f"Error in _timeit_worker: {e}")
+        return None, None, None
+
+
+def timeit_sync(
+        runs: int = 1,
+        workers: int = 1,
+        log_level: Optional[int] = logging.INFO,
+        use_multiprocessing: bool = False,
+        detailed: bool = False,
+        timeout: Optional[float] = None,
+        enforce_timeout: bool = False
+):
+    """
+        Time the execution of a function with options for multiple runs and workers.
+
+        This decorator can use either threading or multiprocessing for executing the
+        function multiple times in parallel, depending on the nature of the task.
+        It measures and logs the execution time, reporting the average and median times.
+
+        :param runs: Number of times to run the function (minimum 1).
+        :type runs: int
+        :param workers: Number of concurrent workers (minimum 1, max equals 'runs').
+        :type workers: int
+        :param log_level: Logging level for timing information (e.g., logging.INFO).
+        :type log_level: Optional[int]
+        :param use_multiprocessing: Use multiprocessing if True, otherwise use threading.
+                                    Suitable for CPU-bound tasks when True.
+        :type use_multiprocessing: bool
+        :param detailed: get a detailed output with different stats about the execution time.
+        :type detailed: bool
+        :param timeout: An optional timeout in seconds for each function execution.
+        :type timeout: Optional[float]
+        :param enforce_timeout: Enforce timeout. False by default. If True and the timeout is reached, it will cancel the
+                                execution. Does not work in single execution in sync mode.
+        :type enforce_timeout: bool
+        :return: The return value of the function from its first execution.
+        :rtype: Any
+        :raises ValueError: If 'runs' or 'workers' are set to less than 1.
+
+        For I/O-bound tasks (like file operations, network calls), threading is generally
+        more efficient due to lower overhead and the GIL's release during I/O operations.
+        For CPU-bound tasks, multiprocessing bypasses the GIL and may provide better performance.
+
+        .. note::
+           Choose the execution mode (threading or multiprocessing) based on the task at hand.
+           Threading is the default mode for its efficiency with I/O-bound tasks.
+
+        **Example**::
+
+            @timeit(runs=10, workers=4, log_level=logging.DEBUG, use_multiprocessing=True)
+            def cpu_intensive_function(n):
+                # Function implementation
+
+            @timeit(runs=5, workers=2)
+            def io_bound_function(n):
+                # Function implementation
+        """
+
+    if runs < 1 or workers < 1:
+        raise ValueError("Both runs and workers must be at least 1")
+
+    # Ensure workers do not exceed number of runs
+    workers = min(workers, runs)
+
+    if log_level is None:
+        log_level = logging.INFO
+
+    def decorator(func: Callable):
+        logger = logging.getLogger("timeit.decorator")
+        logger.setLevel(log_level)
+
+        if not logging.getLogger().hasHandlers():
+            logging.basicConfig(
+                level=log_level,
+                format="%(asctime)s [%(levelname)s] (%(name)s) %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S"
+            )
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+
+            # Prevent nested decorators inside thread/process workers
+            if threading.current_thread() is not threading.main_thread():
+                return func(*args, **kwargs)
+            if multiprocessing.current_process().name != 'MainProcess':
+                return func(*args, **kwargs)
+
+            # Fast path: single run, no concurrency
+            if runs == 1 and workers == 1:
+                if enforce_timeout and timeout:
+                    logger.warning(
+                        "enforce_timeout=True is ignored when runs=1 and workers=1 in sync mode — no parallelism or cancellation is possible.")
+                start_time = time.time()
+                result = func(*args, **kwargs)
+                execution_time = time.time() - start_time
+                if detailed:
+                    output = tabulate([
+                        ["Function", func],
+                        ["Args", args[1:]],
+                        ["Kwargs", kwargs],
+                        ["Duration", f"{execution_time}s"]
+                    ], tablefmt="plain")
+                else:
+                    output = f"{func.__name__}: Exec: {execution_time:.6f}s"
+                logger.log(log_level, output)
+                return result
+
+            # Determine if function is an instance method
+            is_instance_method = args and hasattr(args[0], func.__name__)
+
+            if is_instance_method:
+                # Prepare arguments for instance method execution
+                method_target = args[0]
+                worker_args = [
+                    (method_target, func.__name__, args[1:], kwargs, timeout, enforce_timeout)
+                    # Ensure correct argument structure
+                    for _ in range(runs)
+                ]
+            else:
+                # Prepare arguments for function execution
+                worker_args = [(func, args, kwargs, timeout, enforce_timeout) for _ in range(runs)]
+
+            logger.debug(
+                f"Starting {'multiprocessing' if use_multiprocessing else 'threading'} tasks with {workers} workers")
+
+            # Choose between threading and multiprocessing
+            if use_multiprocessing:
+                if enforce_timeout:
+                    raise ValueError("enforce_timeout=True is not supported with use_multiprocessing=True")
+                with Pool(workers) as pool:
+                    results = pool.map(_timeit_worker, worker_args)
+            else:
+                with ThreadPoolExecutor(max_workers=workers) as executor:
+                    futures = [executor.submit(_timeit_worker, args) for args in worker_args]
+
+                    results = []
+
+                    if enforce_timeout and timeout:
+                        for i, future in enumerate(futures):
+                            try:
+                                result = future.result(timeout=timeout)
+                                results.append(result)
+                            except TimeoutError:
+                                logger.warning(
+                                    f"Function execution {i} exceeded timeout of {timeout}s and was canceled.")
+                                future.cancel()
+                                results.append((timeout, None, True))
+                            except Exception as e:
+                                logger.error(f"Function execution {i} failed with: {e}")
+                                results.append((None, None, None))
+                    else:
+                        for i, future in enumerate(futures):
+                            try:
+                                results.append(future.result())
+                            except Exception as e:
+                                logger.error(f"Function execution {i} failed with: {e}")
+                                results.append((None, None, None))
+
+            # Extract timing and result data
+            times = [r[0] for r in results if r and r[0] is not None]
+            valid_results = [r[1] for r in results if r and r[1] is not None]
+            timed_out = [r[2] for r in results if r and r[2] is not None]
+
+            if not times:
+                logger.error(f"{func.__name__}: All function executions failed or returned None.")
+                return None if not detailed else []
+
+            # Compute statistics
+            avg_time = mean(times)
+            med_time = median(times)
+            min_time = min(times)
+            max_time = max(times)
+            std_dev = stdev(times) if len(times) > 1 else 0
+            total_time = sum(times)
+
+            if detailed:
+                stats_data = [
+                    ["Function", func],
+                    ["Args", args[1:]],
+                    ["Kwargs", kwargs],
+                    ["Runs", runs],
+                    ["Workers", workers],
+                    ["Average Time", f"{avg_time}s"],
+                    ["Median Time", f"{med_time}s"],
+                    ["Min Time", f"{min_time}s"],
+                    ["Max Time", f"{max_time}s"],
+                    ["Std Deviation", f"{std_dev}s"],
+                    ["Total Time", f"{total_time}s"],
+                    ["Timed Out", any(timed_out)],
+                ]
+                output = tabulate(stats_data, tablefmt="plain")
+            else:
+                output = f"{func.__name__}: Avg: {avg_time:.3f}s, Med: {med_time:.3f}s"
+
+            logger.log(log_level, output)
+
+            # Return the first successful result
+            for result in valid_results:
+                if result is not None:
+                    return result
+
+            return None  # Fallback if all runs failed
+
+        return sync_wrapper
+
+    return decorator

--- a/timeit_decorator/timeit.py
+++ b/timeit_decorator/timeit.py
@@ -1,205 +1,26 @@
-import concurrent
-import logging
-import multiprocessing
-import threading
-import time
-from concurrent.futures import ThreadPoolExecutor
-from functools import wraps
-from multiprocessing import Pool
-from statistics import mean, median, stdev
-from typing import Optional, Callable
+import inspect
+import warnings
+from typing import Callable
 
-from tabulate import tabulate
+from .async_wrapper import timeit_async
+from .sync_wrapper import timeit_sync
 
 
-def _multiprocessing_instance_method_call(instance, method_name, *args, **kwargs):
-    method = getattr(instance, method_name)
-    return method(*args, **kwargs)
-
-
-def _timeit_worker(worker_args):
-    """Worker function that executes a function and applies a timeout."""
-    logger = logging.getLogger("timeit.decorator._timeit_worker")
-    try:
-        if isinstance(worker_args, tuple) and isinstance(worker_args[1], str):
-            instance, method_name, *method_args, timeout = worker_args
-            wrapped_func = lambda: getattr(instance, method_name)(*method_args)
-        else:
-            func, func_args, func_kwargs, timeout = worker_args
-            wrapped_func = lambda: func(*func_args, **func_kwargs)
-
-        # Enforce timeout using a thread-based executor
-        func_result = None
-        timed_out = False
-
-        # Execute function without preventing execution on timeout
-        execution_start = time.time()
-        func_result = wrapped_func()
-        execution_time = time.time() - execution_start
-
-        if timeout is not None and execution_time > timeout:
-            logger.warning(f"Timeout exceeded (took {execution_time}s, timeout was {timeout}s), but execution continued.")
-            timed_out = True
-
-        return execution_time, func_result, timed_out
-
-    except Exception as e:
-        logging.error(f"Error in _timeit_worker: {e}")
-        return None, None, None
-
-
-def timeit(
-        runs: int = 1,
-        workers: int = 1,
-        log_level: Optional[int] = logging.INFO,
-        use_multiprocessing: bool = False,
-        detailed: bool = False,
-        timeout: Optional[float] = None  # New parameter for execution timeout
-):
+def timeit(**kwargs):
     """
-    Time the execution of a function with options for multiple runs and workers.
-
-    This decorator can use either threading or multiprocessing for executing the
-    function multiple times in parallel, depending on the nature of the task.
-    It measures and logs the execution time, reporting the average and median times.
-
-    :param runs: Number of times to run the function (minimum 1).
-    :type runs: int
-    :param workers: Number of concurrent workers (minimum 1, max equals 'runs').
-    :type workers: int
-    :param log_level: Logging level for timing information (e.g., logging.INFO). If None, will print directly in the console.
-    :type log_level: Optional[int]
-    :param use_multiprocessing: Use multiprocessing if True, otherwise use threading.
-                                Suitable for CPU-bound tasks when True.
-    :type use_multiprocessing: bool
-    :param detailed: get a detailed output with different stats about the execution time.
-    :type detailed: bool
-    :param timeout: An optional timeout in seconds for each function execution.
-    :type timeout: Optional[float]
-    :return: The return value of the function from its first execution.
-    :rtype: Any
-    :raises ValueError: If 'runs' or 'workers' are set to less than 1.
-
-    For I/O-bound tasks (like file operations, network calls), threading is generally
-    more efficient due to lower overhead and the GIL's release during I/O operations.
-    For CPU-bound tasks, multiprocessing bypasses the GIL and may provide better performance.
-
-    .. note::
-       Choose the execution mode (threading or multiprocessing) based on the task at hand.
-       Threading is the default mode for its efficiency with I/O-bound tasks.
-
-    **Example**::
-
-        @timeit(runs=10, workers=4, log_level=logging.DEBUG, use_multiprocessing=True)
-        def cpu_intensive_function(n):
-            # Function implementation
-
-        @timeit(runs=5, workers=2)
-        def io_bound_function(n):
-            # Function implementation
+    Deprecated. Use @timeit_sync or @timeit_async instead.
+    Automatically forwards based on the function type.
     """
-
-    if runs < 1 or workers < 1:
-        raise ValueError("Both runs and workers must be at least 1")
-
-    workers = min(workers, runs)  # ✅ Prevents more workers than runs
 
     def decorator(func: Callable):
-        logger = logging.getLogger("timeit.decorator")
-        if log_level is not None:
-            logger.setLevel(log_level)
-
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if threading.current_thread() is not threading.main_thread():
-                return func(*args, **kwargs)
-
-            if multiprocessing.current_process().name != 'MainProcess':
-                return func(*args, **kwargs)
-
-            if runs == 1 and workers == 1:
-                start_time = time.time()
-                result = func(*args, **kwargs)
-                execution_time = time.time() - start_time
-                if detailed:
-                    output = tabulate([
-                        ["Function", func],
-                        ["Args", args[1:]],
-                        ["Kwargs", kwargs],
-                        ["Duration", f"{execution_time}s"]
-                    ], tablefmt="plain")
-                else:
-                    output = f"{func.__name__}: Exec: {execution_time:.6f}s"
-                logger.log(log_level, output) if log_level else print(output)
-                return result
-
-            is_instance_method = args and hasattr(args[0], func.__name__)
-
-            if is_instance_method:
-                method_target = args[0]
-                worker_args = [
-                    (method_target, func.__name__, *args[1:], timeout)  # ✅ Ensure correct argument structure
-                    for _ in range(runs)
-                ]
-            else:
-                worker_args = [(func, args, kwargs, timeout) for _ in range(runs)]
-
-            logger.debug(
-                f"Starting {'multiprocessing' if use_multiprocessing else 'threading'} tasks with {workers} workers")
-
-            if use_multiprocessing:
-                with Pool(workers) as pool:
-                    results = pool.map(_timeit_worker, worker_args)
-            else:
-                with ThreadPoolExecutor(max_workers=workers) as executor:
-                    results = list(executor.map(_timeit_worker, worker_args))
-
-            times = [r[0] for r in results if r and r[0] is not None]
-            valid_results = [r[1] for r in results if r and r[1] is not None]
-            timed_out = [r[2] for r in results if r and r[2] is not None]
-
-            if not times:
-                logger.error(f"{func.__name__}: All function executions failed or returned None.")
-                return None if not detailed else []
-
-            avg_time = mean(times)
-            med_time = median(times)
-            min_time = min(times)
-            max_time = max(times)
-            std_dev = stdev(times) if len(times) > 1 else 0
-            total_time = sum(times)
-
-            if detailed:
-                stats_data = [
-                    ["Function", func],
-                    ["Args", args[1:]],
-                    ["Kwargs", kwargs],
-                    ["Runs", runs],
-                    ["Workers", workers],
-                    ["Average Time", f"{avg_time}s"],
-                    ["Median Time", f"{med_time}s"],
-                    ["Min Time", f"{min_time}s"],
-                    ["Max Time", f"{max_time}s"],
-                    ["Std Deviation", f"{std_dev}s"],
-                    ["Total Time", f"{total_time}s"],
-                    ["Timed Out", any(timed_out)],
-                ]
-                output = tabulate(stats_data, tablefmt="plain")
-            else:
-                output = f"{func}: Avg: {avg_time:.3f}s, Med: {med_time:.3f}s"
-
-            if log_level is not None:
-                logger.log(log_level, output)
-            else:
-                print(output)
-
-            # Find the first successful result (not None), or return None if all runs failed
-            for result in valid_results:
-                if result is not None:
-                    return result
-
-            return None  # If all results are None (e.g., due to timeouts)
-
-        return wrapper
+        warnings.warn(
+            "The @timeit decorator is deprecated. Use @timeit_sync or @timeit_async instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        if inspect.iscoroutinefunction(func):
+            return timeit_async(**kwargs)(func)
+        else:
+            return timeit_sync(**kwargs)(func)
 
     return decorator


### PR DESCRIPTION
- Introduced @timeit_async decorator with full feature parity with @timeit_sync
- Added enforce_timeout parameter for hard timeouts in sync and async modes
- Disabled all print() output in favor of structured logging via logging
- Improved timeout behavior (per-task enforcement, shielded async fallback)
- Refactored internal worker logic for instance method and async compatibility
- Updated README with usage examples, limitations, and async documentation
- Added CHANGELOG and enhanced test coverage for new features